### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/sdoc/SDoc.py
+++ b/sdoc/SDoc.py
@@ -130,15 +130,14 @@ class SDoc:
         # Read the target format of the document.
         target_format = config.get('sdoc', 'format', fallback=None)
         if not target_format:
-            raise SDocError("Option 'format' in section 'sdoc' not set in config file '%s'" %
-                            self._args.config_filename)
+            raise SDocError("Option 'format' in section 'sdoc' not set in config file '{0!s}'".format(
+                            self._args.config_filename))
 
         # Read the class name for formatting the SDoc2 nodes into the target format.
         section = 'format_' + target_format
         class_name = config.get(section, 'class', fallback=None)
         if not class_name:
-            raise SDocError("Option 'class' in section '%s' not set in config file '%s'" %
-                            (section, self._args.config_filename))
+            raise SDocError("Option 'class' in section '{0!s}' not set in config file '{1!s}'".format(section, self._args.config_filename))
 
         # Import the class.
         parts = class_name.split('.')
@@ -161,11 +160,11 @@ class SDoc:
         self._temp_dir = config.get('sdoc', 'temp_dir', fallback=self._temp_dir)
 
         if not self._temp_dir:
-            raise SDocError("Option 'temp_dir' in section 'sdoc' not set correctly in config file '%s'" %
-                            self._args.config_filename)
+            raise SDocError("Option 'temp_dir' in section 'sdoc' not set correctly in config file '{0!s}'".format(
+                            self._args.config_filename))
 
         if not os.access(self._temp_dir, os.W_OK):
-            raise SDocError("Directory '%s' is not writable" % self._temp_dir)
+            raise SDocError("Directory '{0!s}' is not writable".format(self._temp_dir))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _config_set_target_dir(self, config):
@@ -177,11 +176,11 @@ class SDoc:
         self._target_dir = config.get('sdoc', 'target_dir', fallback=self._target_dir)
 
         if not self._target_dir:
-            raise SDocError("Option 'target_dir' in section 'sdoc' not set correctly in config file '%s'" %
-                            self._args.config_filename)
+            raise SDocError("Option 'target_dir' in section 'sdoc' not set correctly in config file '{0!s}'".format(
+                            self._args.config_filename))
 
         if not os.access(self._target_dir, os.W_OK):
-            raise SDocError("Directory '%s' is not writable" % self._target_dir)
+            raise SDocError("Directory '{0!s}' is not writable".format(self._target_dir))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_config_file(self):

--- a/sdoc/sdoc1/SDoc1visitor.py
+++ b/sdoc/sdoc1/SDoc1visitor.py
@@ -120,7 +120,7 @@ class SDoc1Visitor(sdoc1ParserVisitor):
         if position == 'stop':
             column += len(token.text)
 
-        self.stream('\\position{%s:%d.%d}' % (sdoc.escape(filename), line_number, column))
+        self.stream('\\position{{{0!s}:{1:d}.{2:d}}}'.format(sdoc.escape(filename), line_number, column))
 
     # ------------------------------------------------------------------------------------------------------------------
     def visit(self, tree):
@@ -146,7 +146,7 @@ class SDoc1Visitor(sdoc1ParserVisitor):
         # Left hand side must be an identifier.
         # @todo implement array element.
         if not isinstance(left_hand_side, IdentifierDataType):
-            raise RuntimeError("Left hand side '%s' is not an identifier." % str(left_hand_side))
+            raise RuntimeError("Left hand side '{0!s}' is not an identifier.".format(str(left_hand_side)))
             # @todo more verbose logging, own exception class
 
         return left_hand_side.set_value(right_hand_side)
@@ -189,11 +189,11 @@ class SDoc1Visitor(sdoc1ParserVisitor):
         # First get the value of key.
         expression = ctx.expression().accept(self)
         if not expression.is_defined():
-            raise RuntimeError('%s is not defined.' % ctx.expression().getText())
+            raise RuntimeError('{0!s} is not defined.'.format(ctx.expression().getText()))
 
         postfix_expression = ctx.postfixExpression().accept(self)
         if not isinstance(postfix_expression, IdentifierDataType):
-            raise RuntimeError("'%s' is not an identifier." % ctx.postfixExpression().getText())
+            raise RuntimeError("'{0!s}' is not an identifier.".format(ctx.postfixExpression().getText()))
             # @todo more verbose logging, own exception class
 
         return postfix_expression.get_array_element(expression)
@@ -336,7 +336,7 @@ class SDoc1Visitor(sdoc1ParserVisitor):
         file_name = sdoc.unescape(ctx.SIMPLE_ARG().getText())
         if not os.path.isabs(file_name):
             file_name = os.path.join(self._root_dir, file_name + '.sdoc')
-        print("Including %s" % os.path.relpath(file_name))
+        print("Including {0!s}".format(os.path.relpath(file_name)))
         stream = antlr4.FileStream(file_name, 'utf-8')
 
         # root_dir
@@ -374,7 +374,7 @@ class SDoc1Visitor(sdoc1ParserVisitor):
         line_number = token.line
         message = sdoc.unescape(ctx.SIMPLE_ARG().getText())
 
-        print('Notice: %s at %s:%d' % (message, os.path.relpath(filename), line_number))
+        print('Notice: {0!s} at {1!s}:{2:d}'.format(message, os.path.relpath(filename), line_number))
 
         self.put_position(ctx, 'stop')
 

--- a/sdoc/sdoc1/data_type/ArrayDataType.py
+++ b/sdoc/sdoc1/data_type/ArrayDataType.py
@@ -40,8 +40,8 @@ class ArrayDataType(DataType):
 
         # Find the length of the longest key.
         for (key, value) in self._elements.items():
-            if len("%s" % key) >= longest:
-                longest = len("%s" % key)
+            if len("{0!s}".format(key)) >= longest:
+                longest = len("{0!s}".format(key))
                 if isinstance(key, str):
                     # The longest key is a string. Add 2 positions for quotes.
                     longest += 2
@@ -119,7 +119,7 @@ class ArrayDataType(DataType):
         @todo consider key must be int or str
         """
         if not key.is_scalar():
-            raise RuntimeError("Key '%s' is not a scalar." % str(key))
+            raise RuntimeError("Key '{0!s}' is not a scalar.".format(str(key)))
 
         self._elements[key.get_value()] = value.dereference()
 
@@ -135,7 +135,7 @@ class ArrayDataType(DataType):
         :rtype: sdoc.sdoc1.data_type.DataType.DataType
         """
         if name not in self._elements:
-            raise RuntimeError("Identifier '%s' does not have a value." % name)
+            raise RuntimeError("Identifier '{0!s}' does not have a value.".format(name))
 
         return self._elements[name]
 

--- a/sdoc/sdoc1/data_type/IdentifierDataType.py
+++ b/sdoc/sdoc1/data_type/IdentifierDataType.py
@@ -47,12 +47,12 @@ class IdentifierDataType(DataType):
         :rtype: str
         """
         if not self._scope.has_element(self._name):
-            return "'%s' = %s" % (self._name, 'UNDEFINED')
+            return "'{0!s}' = {1!s}".format(self._name, 'UNDEFINED')
 
         # Setting first indentation.
-        first_indent = len("%s = " % self._name)
+        first_indent = len("{0!s} = ".format(self._name))
 
-        return "%s = %s" % (self._name, self._scope.get_reference(self._name).debug(first_indent))
+        return "{0!s} = {1!s}".format(self._name, self._scope.get_reference(self._name).debug(first_indent))
 
     # ------------------------------------------------------------------------------------------------------------------
     def dereference(self):

--- a/sdoc/sdoc2/NodeStore.py
+++ b/sdoc/sdoc2/NodeStore.py
@@ -82,7 +82,7 @@ class NodeStore:
 
         if not self.nested_nodes:
             # @todo position
-            raise RuntimeError("Unexpected \\end{%s}." % command)
+            raise RuntimeError("Unexpected \\end{{{0!s}}}.".format(command))
 
         # Get the last node on the block stack.
         node = self.nested_nodes[-1]
@@ -90,7 +90,7 @@ class NodeStore:
         if node.name != command:
             # @todo position \end
             # @todo position \begin
-            raise RuntimeError("\\begin{%s} and \\end{%s} do not match." % (node.name, command))
+            raise RuntimeError("\\begin{{{0!s}}} and \\end{{{1!s}}} do not match.".format(node.name, command))
 
         # Pop the last node of the block stack.
         self.nested_nodes.pop()
@@ -262,11 +262,11 @@ class NodeStore:
         :rtype: sdoc.sdoc2.formatter.Formatter.Formatter
         """
         if self.format not in self._formatters:
-            raise RuntimeError("Unknown output format '%s'." % self.format)
+            raise RuntimeError("Unknown output format '{0!s}'.".format(self.format))
 
         if command not in self._formatters[self.format]:
             # @todo use default none decorator with warning
-            raise RuntimeError("Unknown formatter '%s' for format '%s'." % (command, self.format))
+            raise RuntimeError("Unknown formatter '{0!s}' for format '{1!s}'.".format(command, self.format))
 
         constructor = self._formatters[self.format][command]
         formatter = constructor(parent)
@@ -289,8 +289,7 @@ class NodeStore:
                 if node.is_hierarchy_root():
                     parent_found = True
                 else:
-                    raise RuntimeError("Improper nesting of node '%s' at %s and node '%s' at %s." %
-                                       (parent_node.name, parent_node.position, node.name, node.position))
+                    raise RuntimeError("Improper nesting of node '{0!s}' at {1!s} and node '{2!s}' at {3!s}.".format(parent_node.name, parent_node.position, node.name, node.position))
 
             if not parent_found:
                 parent_hierarchy_level = parent_node.get_hierarchy_level()
@@ -306,8 +305,7 @@ class NodeStore:
 
         if node_hierarchy_level - parent_hierarchy_level > 1:
             # @todo position
-            print("Warning improper nesting of levels: %d at %s and %d at %s." %
-                  (parent_hierarchy_level, parent_node.position, node_hierarchy_level, node.position))
+            print("Warning improper nesting of levels: {0:d} at {1!s} and {2:d} at {3!s}.".format(parent_hierarchy_level, parent_node.position, node_hierarchy_level, node.position))
 
     # ------------------------------------------------------------------------------------------------------------------
     def store_node(self, node):
@@ -339,7 +337,7 @@ class NodeStore:
             # The first node must be a document root.
             if not node.is_document_root():
                 # @todo position of block node.
-                raise RuntimeError("Node %s is not a document root" % node.name)
+                raise RuntimeError("Node {0!s} is not a document root".format(node.name))
 
             self.nested_nodes.append(node)
 
@@ -347,7 +345,7 @@ class NodeStore:
             # All other nodes must not be a document root.
             if node.is_document_root():
                 # @todo position of block node.
-                raise RuntimeError("Unexpected %s. Node is document root" % node.name)
+                raise RuntimeError("Unexpected {0!s}. Node is document root".format(node.name))
 
             # If the node is a part of a hierarchy adjust the nested nodes stack.
             if node.get_hierarchy_name():

--- a/sdoc/sdoc2/Position.py
+++ b/sdoc/sdoc2/Position.py
@@ -59,7 +59,7 @@ class Position:
 
     # ------------------------------------------------------------------------------------------------------------------
     def __str__(self):
-        return "%s:%d.%d" % (os.path.relpath(self.file_name), self.start_line, self.start_column+1)
+        return "{0!s}:{1:d}.{2:d}".format(os.path.relpath(self.file_name), self.start_line, self.start_column+1)
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/sdoc/sdoc2/SDoc2visitor.py
+++ b/sdoc/sdoc2/SDoc2visitor.py
@@ -160,7 +160,7 @@ class SDoc2Visitor(sdoc2ParserVisitor):
         argument = ctx.INLINE_ARG_ARG()
         parts = re.match(r'(.+):([0-9]+)\.([0-9]+)', str(argument))
         if not parts:
-            raise RuntimeError('%s is not a valid position' % argument)
+            raise RuntimeError('{0!s} is not a valid position'.format(argument))
 
         self._sdoc1_file_name = parts.group(1)
         self._sdoc1_line = int(parts.group(2))

--- a/sdoc/sdoc2/formatter/html/FigureHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/FigureHtmlFormatter.py
@@ -23,7 +23,7 @@ class FigureHtmlFormatter(HtmlFormatter):
         :param sdoc.sdoc2.node.FigureNode.FigureNode node: The figure node.
         :param file file: The output file.
         """
-        text_in_tag = '%s %s' % (node._options['number'], '---FIGURE---')
+        text_in_tag = '{0!s} {1!s}'.format(node._options['number'], '---FIGURE---')
         file.write(Html.generate_element('h3', {}, text_in_tag))
 
         super().generate(node, file)

--- a/sdoc/sdoc2/formatter/html/HeadingHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/HeadingHtmlFormatter.py
@@ -23,8 +23,8 @@ class HeadingHtmlFormatter(HtmlFormatter):
         :param sdoc.sdoc2.node.HeadingNode.HeadingNode node: The heading node.
         :param file file: The output file.
         """
-        text_in_tag = '%s %s' % (node._options['number'], node.argument)
-        file.write(Html.generate_element('h%d' % node.get_hierarchy_level(), {}, text_in_tag))
+        text_in_tag = '{0!s} {1!s}'.format(node._options['number'], node.argument)
+        file.write(Html.generate_element('h{0:d}'.format(node.get_hierarchy_level()), {}, text_in_tag))
 
         super().generate(node, file)
 

--- a/sdoc/sdoc2/formatter/html/UnknownHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/UnknownHtmlFormatter.py
@@ -24,7 +24,7 @@ class UnknownHtmlFormatter(HtmlFormatter):
         :param sdoc.sdoc2.node.ParagraphNode.ParagraphNode node: The paragraph node.
         :param file file: The output file.
         """
-        html = 'Unknown SDoc2 command <span style="font-weight:bold">%s</span> at %s' % (
+        html = 'Unknown SDoc2 command <span style="font-weight:bold">{0!s}</span> at {1!s}'.format(
             Html.escape(node.name), Html.escape(str(node.position)))
         file.write(Html.generate_element('span', {'style': 'color:red'}, html, True))
 

--- a/sdoc/sdoc2/node/FigureNode.py
+++ b/sdoc/sdoc2/node/FigureNode.py
@@ -63,7 +63,7 @@ class FigureNode(Node):
         chapter = HeadingNode.get_numeration(enumerable_numbers, 1)
 
         if 'figures' not in enumerable_numbers:
-            enumerable_numbers['figures'] = '%s.%s' % (chapter, '0')
+            enumerable_numbers['figures'] = '{0!s}.{1!s}'.format(chapter, '0')
 
         else:
             numbers_level = enumerable_numbers['figures'].split('.')

--- a/sdoc/sdoc2/node/HeadingNode.py
+++ b/sdoc/sdoc2/node/HeadingNode.py
@@ -68,7 +68,7 @@ class HeadingNode(Node):
         """
         if string_of_numbers.startswith('0'):
             string_of_numbers = string_of_numbers.lstrip('0.')
-            string_of_numbers = '0.%s' % string_of_numbers
+            string_of_numbers = '0.{0!s}'.format(string_of_numbers)
 
         return string_of_numbers
 

--- a/sdoc/sdoc2/node/HyperlinkNode.py
+++ b/sdoc/sdoc2/node/HyperlinkNode.py
@@ -65,10 +65,10 @@ class HyperlinkNode(Node):
         """
         if not request.urlparse(url).scheme:
             if url.startswith('ftp.'):
-                url = 'ftp://%s' % url
+                url = 'ftp://{0!s}'.format(url)
                 self._options['href'] = url
             else:
-                url = 'http://%s' % url
+                url = 'http://{0!s}'.format(url)
                 self._options['href'] = url
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -82,7 +82,7 @@ class HyperlinkNode(Node):
 
             # Check if we can connect to host.
             if response.getcode() not in range(200, 400):
-                print("Warning! - Cannot connect to: '%s'" % self._options['href'])
+                print("Warning! - Cannot connect to: '{0!s}'".format(self._options['href']))
             else:
                 # If we connected, check the redirect.
                 url = self._options['href'].lstrip('(http://)|(https://)')
@@ -97,7 +97,7 @@ class HyperlinkNode(Node):
                         self._options['href'].replace('http://', 'https://')
 
         except error.URLError:
-            print("Warning! - Invalid url address: '%s'" % self._options['href'])
+            print("Warning! - Invalid url address: '{0!s}'".format(self._options['href']))
 
     # ------------------------------------------------------------------------------------------------------------------
     def get_command(self):

--- a/sdoc/sdoc2/node/ItemizeNode.py
+++ b/sdoc/sdoc2/node/ItemizeNode.py
@@ -105,7 +105,7 @@ class ItemizeNode(Node):
             node = in_scope(node_id)
 
             if not isinstance(node, ItemNode):
-                raise RuntimeError("Node: id:%s, %s is not instance of 'ItemNode'" % (str(node.id), node.name))
+                raise RuntimeError("Node: id:{0!s}, {1!s} is not instance of 'ItemNode'".format(str(node.id), node.name))
 
             out_scope(node)
 

--- a/sdoc/sdoc2/node/Node.py
+++ b/sdoc/sdoc2/node/Node.py
@@ -84,7 +84,7 @@ class Node:
 
         :param int level: the level of block commands.
         """
-        print("%s%4d %s" % (' ' * 4 * level, self.id, self.name))
+        print("{0!s}{1:4d} {2!s}".format(' ' * 4 * level, self.id, self.name))
         for node_id in self._child_nodes:
             node = in_scope(node_id)
 

--- a/sdoc/sdoc2/node/TextNode.py
+++ b/sdoc/sdoc2/node/TextNode.py
@@ -34,7 +34,7 @@ class TextNode(Node):
 
         :param int level: the level of block commands.
         """
-        print("%s%4d %s %s" % (' ' * 4 * level, self.id, self.name, ''))
+        print("{0!s}{1:4d} {2!s} {3!s}".format(' ' * 4 * level, self.id, self.name, ''))
 
     # ------------------------------------------------------------------------------------------------------------------
     def get_command(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SDoc:py-sdoc?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SDoc:py-sdoc?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)