### PR TITLE
SDoc-47: Errors with references in tables

### DIFF
--- a/bin/sdoc
+++ b/bin/sdoc
@@ -8,4 +8,3 @@ from sdoc.SDoc import SDoc
 
 sdoc = SDoc()
 sdoc.main()
-

--- a/sdoc/sdoc2/NodeStore.py
+++ b/sdoc/sdoc2/NodeStore.py
@@ -77,6 +77,18 @@ class NodeStore:
         """
 
     # ------------------------------------------------------------------------------------------------------------------
+    def get_formatter(self, output_type, name_formatter):
+        """
+        Returns the formatter for special type.
+
+        :param str output_type: The type of output formatter (e.g. 'html')
+        :param str name_formatter: The name of formatter (e.g. 'smile')
+
+        :rtype: sdoc.sdoc2.formatter.Formatter.Formatter
+        """
+        return self._formatters[output_type][name_formatter]
+
+    # ------------------------------------------------------------------------------------------------------------------
     def end_block_node(self, command):
         """
         Signals the end of a block command.

--- a/sdoc/sdoc2/formatter/html/HyperlinkHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/HyperlinkHtmlFormatter.py
@@ -23,7 +23,7 @@ class HyperlinkHtmlFormatter(HtmlFormatter):
         :param sdoc.sdoc2.node.HyperlinkNode.HyperlinkNode node: The hyperlink node.
         :param file file: The output file.
         """
-        file.write(Html.generate_element('a', node.get_html_attributes(), node.argument))
+        file.write(HyperlinkHtmlFormatter.get_html(node))
 
     # ------------------------------------------------------------------------------------------------------------------
     def generate_chapter(self, node, file):
@@ -34,7 +34,19 @@ class HyperlinkHtmlFormatter(HtmlFormatter):
         :param file file: The output file.
         """
         if file:
-            file.write(Html.generate_element('a', node.get_html_attributes(), node.argument))
+            file.write(HyperlinkHtmlFormatter.get_html(node))
+
+    # ------------------------------------------------------------------------------------------------------------------
+    @staticmethod
+    def get_html(node):
+        """
+        Returns string with generated HTML tag.
+
+        :param sdoc.sdoc2.node.HyperlinkNode.HyperlinkNode node: The hyperlink node.
+
+        :rtype: str
+        """
+        return Html.generate_element('a', node.get_html_attributes(), node.argument)
 
 # ----------------------------------------------------------------------------------------------------------------------
 node_store.register_formatter('hyperlink', 'html', HyperlinkHtmlFormatter)

--- a/sdoc/sdoc2/formatter/html/ReferenceHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/ReferenceHtmlFormatter.py
@@ -50,11 +50,22 @@ class ReferenceHtmlFormatter(HtmlFormatter):
         :param sdoc.sdoc2.node.ReferenceNode.ReferenceNode node: The reference node.
         :param file file: The output file.
         """
+        file.write(ReferenceHtmlFormatter.get_html(node))
+
+    # ------------------------------------------------------------------------------------------------------------------
+    @staticmethod
+    def get_html(node):
+        """
+        Returns string with generated HTML tag.
+
+        :param sdoc.sdoc2.node.ReferenceNode.ReferenceNode node: The reference node.
+
+        :rtype: str
+        """
         attributes = {'class': node.get_option_value('class'),
                       'href': node.get_option_value('href')}
 
-        file.write(Html.generate_element('a', attributes, node.argument))
-
+        return Html.generate_element('a', attributes, node.argument)
 
 # ----------------------------------------------------------------------------------------------------------------------
 node_store.register_formatter('ref', 'html', ReferenceHtmlFormatter)

--- a/sdoc/sdoc2/formatter/html/SmileHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/SmileHtmlFormatter.py
@@ -23,7 +23,7 @@ class SmileHtmlFormatter(HtmlFormatter):
         :param sdoc.sdoc2.node.SmileNode.SmileNode node: The smile node.
         :param file file: The output file.
         """
-        file.write(Html.generate_element('b', {}, 'SMILE'))
+        file.write(SmileHtmlFormatter.get_html(node))
 
         super().generate(node, file)
 
@@ -36,10 +36,21 @@ class SmileHtmlFormatter(HtmlFormatter):
         :param file file: The output file.
         """
         if file:
-            file.write(Html.generate_element('b', {}, 'SMILE'))
+            file.write(SmileHtmlFormatter.get_html(node))
 
         super().generate_chapter(node, file)
 
+    # ------------------------------------------------------------------------------------------------------------------
+    @staticmethod
+    def get_html(node):
+        """
+        Returns string with generated HTML tag.
+
+        :param sdoc.sdoc2.node.SmileNode.SmileNode node: The smile node.
+
+        :rtype: str
+        """
+        return Html.generate_element('b', {}, 'SMILE')
 
 # ----------------------------------------------------------------------------------------------------------------------
 node_store.register_formatter('smile', 'html', SmileHtmlFormatter)

--- a/sdoc/sdoc2/formatter/html/TableHtmlFormatter.py
+++ b/sdoc/sdoc2/formatter/html/TableHtmlFormatter.py
@@ -9,6 +9,7 @@ Licence MIT
 from sdoc.helper.Html import Html
 from sdoc.sdoc2 import node_store
 from sdoc.sdoc2.formatter.html.HtmlFormatter import HtmlFormatter
+from sdoc.sdoc2.node.ReferenceNode import ReferenceNode
 
 
 class TableHtmlFormatter(HtmlFormatter):
@@ -96,14 +97,12 @@ class TableHtmlFormatter(HtmlFormatter):
         table_header = Html.generate_element('tr', {}, table_header, True)
 
         header_column_counter = 0
+
         for row in node.rows:
             for col in row:
                 align = TableHtmlFormatter.get_align(node.alignments, header_column_counter)
 
-                if align:
-                    columns += Html.generate_element('td', {'style': "text-align: {0}".format(align)}, col)
-                else:
-                    columns += Html.generate_element('td', {}, col)
+                columns += TableHtmlFormatter.generate_column(align, col)
 
                 header_column_counter += 1
             rows += Html.generate_element('tr', {}, columns, True)
@@ -111,6 +110,37 @@ class TableHtmlFormatter(HtmlFormatter):
             header_column_counter = 0
 
         return table_header + rows
+
+    # ------------------------------------------------------------------------------------------------------------------
+    @staticmethod
+    def generate_column(align, col):
+        """
+        Returns the 'column' with HTML data.
+
+        :param mixed col: The column in a table.
+
+        :rtype: str
+        """
+        if isinstance(col, str):
+            if align:
+                column = Html.generate_element('td', {'style': "text-align: {0}".format(align)}, col)
+            else:
+                column = Html.generate_element('td', {}, col)
+
+        else:
+            # Generates html in nested node ('col') with specified formatter.
+            formatter = node_store.get_formatter('html', col.get_command())
+            node_html = formatter.get_html(col)
+
+            if align:
+                column = Html.generate_element('td',
+                                               {'style': "text-align: {0}".format(align)},
+                                               node_html,
+                                               is_html=True)
+            else:
+                column = Html.generate_element('td', {}, node_html, is_html=True)
+
+        return column
 
     # ------------------------------------------------------------------------------------------------------------------
     @staticmethod

--- a/sdoc/sdoc2/node/TableNode.py
+++ b/sdoc/sdoc2/node/TableNode.py
@@ -181,13 +181,14 @@ class TableNode(Node):
             row = []
 
             for data in item:
-                if isinstance(data, str):
+                if data and isinstance(data, str) and not data.isspace():
                     string = io.StringIO(data)
                     self.parse_vertical_separators(string, row)
                 else:
                     row.append(data)
 
-            rows.append(row)
+            if row:
+                rows.append(row)
 
         return rows
 


### PR DESCRIPTION
Finally I've done this task. Now we can use in tables special tags like '\\notice', '\\expression' etc. Also we can use hyperlinks, references and smiles. 
This pull request automatically fixes problems in SDoc-48 task.

p.s. I've attached file for test tables in different consequences if added 'special tags' in tables.

Looks like all works good.

[test_tables.sdoc.zip](https://github.com/SDoc/py-sdoc/files/363965/test_tables.sdoc.zip)
